### PR TITLE
Mis à jour des nouvelles URL Banque Populaire

### DIFF
--- a/shared/banks.json
+++ b/shared/banks.json
@@ -80,12 +80,20 @@
                         "label": "Alsace (www.ibps.alsace.banquepopulaire.fr)"
                     },
                     {
+                        "value": "www.ibps.bpalc.banquepopulaire.fr",
+                        "label": "Alsace Lorraine Champagne (www.ibps.bpalc.banquepopulaire.fr)"
+                    },
+                    {
                         "value": "www.ibps.bpaca.banquepopulaire.fr",
                         "label": "Aquitaine Centre atlantique (www.ibps.bpaca.banquepopulaire.fr)"
                     },
                     {
                         "value": "www.ibps.atlantique.banquepopulaire.fr",
                         "label": "Atlantique (www.ibps.atlantique.banquepopulaire.fr)"
+                    },
+                    {
+                        "value": "www.ibps.bpaura.banquepopulaire.fr",
+                        "label": "Auvergne Rhône Alpes (www.ibps.bpaura.banquepopulaire.fr)"
                     },
                     {
                         "value": "www.ibps.banquedesavoie.banquepopulaire.fr",
@@ -126,6 +134,10 @@
                     {
                         "value": "www.ibps.nord.banquepopulaire.fr",
                         "label": "Nord (www.ibps.nord.banquepopulaire.fr)"
+                    },
+                    {
+                        "value": "www.ibps.mediterranee.banquepopulaire.fr",
+                        "label": "Méditerranée (www.ibps.mediterranee.banquepopulaire.fr)"
                     },
                     {
                         "value": "www.ibps.occitane.banquepopulaire.fr",


### PR DESCRIPTION
Pour l'instant, j'ai juste ajouté les URLs manquantes par rapport à https://git.weboob.org/weboob/stable/blob/master/modules/banquepopulaire/module.py .

Je me propose dans un deuxième temps de retirer les URLs qui ont été supprimées de ce fichier.

Dans l'idéal, il serait encore meilleur de récupérer la liste dans le 'website_choices' de la classe gérant  le module dans weboob, mais tous les modules ne l'ont pas.